### PR TITLE
Remove auth middleware for the regular use case when creating a new e…

### DIFF
--- a/src/routes/establishmentsRouter.js
+++ b/src/routes/establishmentsRouter.js
@@ -11,8 +11,8 @@ module.exports = function establishmentsRouter() {
     express.Router()
       .get('/', authenticationMiddleware, establishmentsController.get)
       .post('/', establishmentsController.add)
-      .get('/:establishmentId', authenticationMiddleware, establishmentsController.getSingleEstablishment)
-      .get('/PDF/:establishmentId', authenticationMiddleware, establishmentsController.getEstablishmentPDF)
+      .get('/:establishmentId', establishmentsController.getSingleEstablishment)
+      .get('/PDF/:establishmentId', establishmentsController.getEstablishmentPDF)
       .put('/:establishmentId', authenticationMiddleware, establishmentsController.update)
       .delete('/:establishmentId', authenticationMiddleware, establishmentsController.remove)
   );

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -223,18 +223,6 @@ describe('App test', () => {
             expect(res.header['content-disposition']).toContain('attachment');
           });
         });
-
-        test('should fail if using invalid token', async () => {
-          await request(server).get(`/establishments/PDF/${establishment_id1}`).set('access-token', invalidToken).then(res => {
-            expect(res.status).toBe(401);
-          });
-        });
-
-        test('should fail if not sending token', async () => {
-          await request(server).get(`/establishments/PDF/${establishment_id1}`).then(res => {
-            expect(res.status).toBe(400);
-          });
-        });
       });
 
       describe('add visits', () => {


### PR DESCRIPTION
…stablishment

Me di cuenta que los tests E2E estaban fallando y era xq se agregó el chequeo del access token en los endpoints para leer un establishment en particular y generar el QR. Al principio habíamos dicho que esa pantalla debería estar pública cosa que cualquier negocio pueda generar su QR sin necesidad de loguearse, entonces no tendría access token. Avisen si no cierra :)

output de correr los tests e2e ahora
![image](https://user-images.githubusercontent.com/22566107/107894564-c6c5a900-6f0e-11eb-87b1-d9648a4f799d.png)
